### PR TITLE
✨ Feature: Upcoming Concerts 페이지 기능 구현 및 스타일링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import {Route, Routes} from "react-router";
 import Layout from "./layout/Layout";
 import Home from "./pages/home/Home";
-import UpcomingConcerts from "./pages/home/upcoming_concerts/UpcomingConcerts";
+import UpcomingConcerts from "./features/upcoming_concerts/UpcomingConcerts";
 
 export default function App() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
-import { Route, Routes } from "react-router";
+import {Route, Routes} from "react-router";
 import Layout from "./layout/Layout";
 import Home from "./pages/home/Home";
+import UpcomingConcerts from "./pages/home/upcoming_concerts/UpcomingConcerts";
 
 export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route path="/" element={<Home />} />
+        <Route path='/' element={<Home />} />
+        <Route path='/upcoming-concerts' element={<UpcomingConcerts />} />
       </Route>
     </Routes>
   );

--- a/src/apis/upcoming_concerts/aixosClient.ts
+++ b/src/apis/upcoming_concerts/aixosClient.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const axiosClient = axios.create({
+  baseURL: "http://13.125.208.179:5007",
+});

--- a/src/apis/upcoming_concerts/getConcerts.ts
+++ b/src/apis/upcoming_concerts/getConcerts.ts
@@ -1,0 +1,14 @@
+import {axiosClient} from "./aixosClient";
+
+type GetConcertsParams = {
+  channelId: string;
+};
+
+export const getConcerts = async ({channelId}: GetConcertsParams) => {
+  try {
+    const response = await axiosClient.get(`/posts/channel/${channelId}`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching concerts:", error);
+  }
+};

--- a/src/components/upcoming_concerts/ConcertCard.tsx
+++ b/src/components/upcoming_concerts/ConcertCard.tsx
@@ -9,14 +9,16 @@ export default function ConcertCard({data}: {data: Concert}) {
 
   return (
     <a href={url} target='_blank'>
-      <div className='w-[320px] h-[580px] rounded border shadow-2xl'>
-        <img src={image} className='w-[320px] h-[400px]' />
-        <div className='p-4'>
-          <h2>{title}</h2>
-          <h2>{artist}</h2>
-          <p>{date}</p>
-          <p>In {place}</p>
+      <div className='w-[320px] h-[580px] border-b border-[var(--white)]'>
+        <img src={image} className='w-80 h-[400px]' />
+        <div className='mt-10 mb-4'>
+          <h2 className='w-[320px] truncate text-[26px] text-[var(--primary-300)] font-bold'>
+            {title}
+          </h2>
+          <h3 className='text-[18px] font-bold'>{artist}</h3>
+          <p className='text-[14px]'>{date}</p>
         </div>
+        <p className='text-[12px]'>in {place}</p>
       </div>
     </a>
   );

--- a/src/components/upcoming_concerts/ConcertCard.tsx
+++ b/src/components/upcoming_concerts/ConcertCard.tsx
@@ -1,11 +1,23 @@
-export default function ConcertCard() {
+import {Concert} from "../../types/upcoming_concerts/Concert";
+
+export default function ConcertCard({data}: {data: Concert}) {
+  const {
+    id,
+    image,
+    title: {title, artist, date, place, url},
+  } = data;
+
   return (
-    <a href={""} target='_blank' className='w-[320px] h-[580px] border '>
-      <img src='{img}' className='w-full h-[400px]' />
-      <h2>title</h2>
-      <h3>artist</h3>
-      <p>date</p>
-      <p>in place</p>
+    <a href={url} target='_blank'>
+      <div className='w-[320px] h-[580px] rounded border shadow-2xl'>
+        <img src={image} className='w-[320px] h-[400px]' />
+        <div className='p-4'>
+          <h2>{title}</h2>
+          <h2>{artist}</h2>
+          <p>{date}</p>
+          <p>In {place}</p>
+        </div>
+      </div>
     </a>
   );
 }

--- a/src/components/upcoming_concerts/ConcertCard.tsx
+++ b/src/components/upcoming_concerts/ConcertCard.tsx
@@ -1,0 +1,11 @@
+export default function ConcertCard() {
+  return (
+    <a href={""} target='_blank' className='w-[320px] h-[580px] border '>
+      <img src='{img}' className='w-full h-[400px]' />
+      <h2>title</h2>
+      <h3>artist</h3>
+      <p>date</p>
+      <p>in place</p>
+    </a>
+  );
+}

--- a/src/features/upcoming_concerts/UpcomingConcerts.tsx
+++ b/src/features/upcoming_concerts/UpcomingConcerts.tsx
@@ -6,22 +6,26 @@ export default function UpcomingConcerts() {
   const {concerts, loading} = useConcerts(channelId);
 
   return (
-    <>
-      <h1 className='text-2xl mb-4'>
-        UPCOMING
-        <br /> CONCERTS in KOREA
-      </h1>
-      <div className='w-[60%]'>
+    <div className='mt-12 flex flex-col justify-center items-center'>
+      <div className='w-full grid grid-cols-4 gap-20'>
+        <h1 className='text-[55px] font-[MonumentExtended] leading-17'>
+          <span className='block'>UPCOMING</span>
+          <span className='text-[var(--primary-300)]'>CONCERTS</span>
+          <span>&nbsp;in&nbsp;</span>
+          <span className='text-[var(--primary-300)]'>KOREA</span>
+        </h1>
+      </div>
+      <div className='flex justify-center mt-16'>
         {loading ? (
           <p>Loading...</p>
         ) : (
-          <div className='grid gap-4'>
+          <div className='grid grid-cols-4 gap-20'>
             {concerts.map((concert, index) => (
               <ConcertCard key={index} data={concert} />
             ))}
           </div>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/features/upcoming_concerts/UpcomingConcerts.tsx
+++ b/src/features/upcoming_concerts/UpcomingConcerts.tsx
@@ -7,7 +7,7 @@ export default function UpcomingConcerts() {
 
   return (
     <div className='mt-12 flex flex-col justify-center items-center'>
-      <div className='w-full grid grid-cols-4 gap-20'>
+      <div className='w-full  gap-20'>
         <h1 className='text-[55px] font-[MonumentExtended] leading-17'>
           <span className='block'>UPCOMING</span>
           <span className='text-[var(--primary-300)]'>CONCERTS</span>

--- a/src/features/upcoming_concerts/UpcomingConcerts.tsx
+++ b/src/features/upcoming_concerts/UpcomingConcerts.tsx
@@ -1,0 +1,27 @@
+import ConcertCard from "../../components/upcoming_concerts/ConcertCard";
+import useConcerts from "../../hooks/useConcerts";
+
+export default function UpcomingConcerts() {
+  const channelId = "681728150949dd30548aa760"; // Upcoming Concerts channel
+  const {concerts, loading} = useConcerts(channelId);
+
+  return (
+    <>
+      <h1 className='text-2xl mb-4'>
+        UPCOMING
+        <br /> CONCERTS in KOREA
+      </h1>
+      <div className='w-[60%]'>
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <div className='grid gap-4'>
+            {concerts.map((concert, index) => (
+              <ConcertCard key={index} data={concert} />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useConcerts.ts
+++ b/src/hooks/useConcerts.ts
@@ -1,0 +1,36 @@
+import {useEffect, useState} from "react";
+import {getConcerts} from "../apis/upcoming_concerts/getConcerts";
+import {Concert} from "../types/upcoming_concerts/Concert";
+
+export default function useConcerts(channelId: string) {
+  const [concerts, setConcerts] = useState<Concert[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchConcerts = async () => {
+      try {
+        const response = await getConcerts({
+          channelId: channelId,
+        });
+
+        const concertData = response.map(
+          (concert: {_id: string; image: string; title: string}) => ({
+            id: concert._id,
+            image: concert.image,
+            title: JSON.parse(concert.title),
+          })
+        );
+
+        setConcerts(concertData);
+      } catch (error) {
+        console.error("콘서트 데이터를 불러오는데 실패했습니다.", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchConcerts();
+  }, [channelId]);
+
+  return {concerts, loading};
+}

--- a/src/hooks/useConcerts.ts
+++ b/src/hooks/useConcerts.ts
@@ -21,7 +21,16 @@ export default function useConcerts(channelId: string) {
           })
         );
 
-        setConcerts(concertData);
+        // 날짜 기준으로 오름차순 정렬
+        const sortedConcerts = concertData.sort((a: Concert, b: Concert) => {
+          const dateA = a.title.date; // 날짜는 문자열 형식 그대로 비교
+          const dateB = b.title.date; // 날짜는 문자열 형식 그대로 비교
+
+          // 문자열 비교
+          return dateA.localeCompare(dateB); // "2025년 5월"과 "2025년 7월" 등을 문자열로 비교
+        });
+
+        setConcerts(sortedConcerts);
       } catch (error) {
         console.error("콘서트 데이터를 불러오는데 실패했습니다.", error);
       } finally {

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,9 +1,13 @@
+import {Outlet} from "react-router";
 import Header from "./header/Header";
 
 export default function Layout() {
   return (
-    <div className="py-4 px-[104px]">
+    <div className='py-4 px-[104px]'>
       <Header />
+      <div className='flex justify-center'>
+        <Outlet />
+      </div>
     </div>
   );
 }

--- a/src/layout/header/MainNav.tsx
+++ b/src/layout/header/MainNav.tsx
@@ -1,51 +1,43 @@
-import { NavLink } from "react-router";
+import {NavLink} from "react-router";
 
 export default function MainNav() {
   return (
-    <nav className="flex gap-12 items-center h-[88px]">
+    <nav className='flex gap-12 items-center h-[88px]'>
       <NavLink
-        to="/"
-        className={({ isActive }) =>
+        to='/upcoming-concerts'
+        className={({isActive}) =>
           `text-[18px] ${
-            isActive
-              ? "text-[color:var(--primary-300)]"
-              : "text-[color:var(--white)]"
+            isActive ? "text-[color:var(--primary-300)]" : "text-[color:var(--white)]"
           }`
         }
       >
         UPCOMING CONCERTS
       </NavLink>
       <NavLink
-        to="/"
-        className={({ isActive }) =>
+        to='/'
+        className={({isActive}) =>
           `text-[18px] ${
-            isActive
-              ? "text-[color:var(--primary-300)]"
-              : "text-[color:var(--white)]"
+            isActive ? "text-[color:var(--primary-300)]" : "text-[color:var(--white)]"
           }`
         }
       >
         PLAYLIST
       </NavLink>
       <NavLink
-        to="/"
-        className={({ isActive }) =>
+        to='/'
+        className={({isActive}) =>
           `text-[18px] ${
-            isActive
-              ? "text-[color:var(--primary-300)]"
-              : "text-[color:var(--white)]"
+            isActive ? "text-[color:var(--primary-300)]" : "text-[color:var(--white)]"
           }`
         }
       >
         COMMUNITY
       </NavLink>
       <NavLink
-        to="/"
-        className={({ isActive }) =>
+        to='/'
+        className={({isActive}) =>
           `text-[18px] ${
-            isActive
-              ? "text-[color:var(--primary-300)]"
-              : "text-[color:var(--white)]"
+            isActive ? "text-[color:var(--primary-300)]" : "text-[color:var(--white)]"
           }`
         }
       >

--- a/src/pages/home/upcoming_concerts/UpcomingConcerts.tsx
+++ b/src/pages/home/upcoming_concerts/UpcomingConcerts.tsx
@@ -1,7 +1,0 @@
-export default function UpcomingConcerts() {
-  return (
-    <>
-      <h1>UpcomingConcerts Component</h1>
-    </>
-  );
-}

--- a/src/pages/home/upcoming_concerts/UpcomingConcerts.tsx
+++ b/src/pages/home/upcoming_concerts/UpcomingConcerts.tsx
@@ -1,0 +1,7 @@
+export default function UpcomingConcerts() {
+  return (
+    <>
+      <h1>UpcomingConcerts Component</h1>
+    </>
+  );
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -50,9 +50,10 @@
   font-style: normal;
 }
 
+/* Pretendard-SemiBold로 지정되어 있어 수정했습니다 ! */
 @font-face {
   font-family: "MonumentExtended";
-  src: url("/src/assets/fonts/Pretendard-SemiBold.woff2") format("woff2");
+  src: url("/src/assets/fonts/MonumentExtended-Regular.otf") format("woff2");
 }
 
 body {

--- a/src/types/upcoming_concerts/Concert.ts
+++ b/src/types/upcoming_concerts/Concert.ts
@@ -1,0 +1,11 @@
+export type Concert = {
+  id: string;
+  image: string;
+  title: {
+    title: string;
+    artist: string;
+    date: string;
+    place: string;
+    url: string;
+  };
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #22 

## 📝작업 내용

> - 내한 콘서트 데이터 불러오기
>   - 콘서트 카드 정렬은 콘서트 시작 날짜 기준 오름차순으로 정렬되어 있습니다.
>   - J-POP 내한 공연은 제외했습니다.
>  - 페이지 스타일링
>    - 스켈레톤 UI, 반응형 작업은 포함되지 않았습니다.

### 스크린샷 (선택)

![스크린샷 2025-05-09 12 33 31](https://github.com/user-attachments/assets/983574ab-efba-4dad-ae86-4d8361aa3f20)


## 💬리뷰 요구사항(선택)

