### PR TITLE
🐛 새로고침 및 메세지 전송 시 업데이트 기능 수정

### DIFF
--- a/src/features/chat/components/Conversations.tsx
+++ b/src/features/chat/components/Conversations.tsx
@@ -5,6 +5,7 @@ import useGetConversation from "../hooks/useGetConversation";
 import UserList from "./UserList";
 import { RotateCcw } from "lucide-react";
 import { useRefreshStore } from "../stores/refreshStore";
+import { useMsgVersionStore } from "../stores/msgVersionStore";
 
 export default function Conversations() {
   const [searchInput, setSearchInput] = useState("");
@@ -13,8 +14,11 @@ export default function Conversations() {
     (state) => state.setRefreshConversations
   );
 
-  const refreshConv = useRefreshStore((state) => state.refreshConversations);
-  const refreshMsg = useRefreshStore((state) => state.refreshMessages);
+  // const refreshConv = useRefreshStore((state) => state.refreshConversations);
+  // const refreshMsg = useRefreshStore((state) => state.refreshMessages);
+
+  const updateCversion = useMsgVersionStore((state) => state.c_increment);
+  const updateMVersion = useMsgVersionStore((state) => state.m_increment);
 
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString("ko-KR", {
@@ -29,8 +33,11 @@ export default function Conversations() {
   }, [refresh, setRefreshConv]);
 
   const refreshHandler = () => {
-    refreshConv?.();
-    refreshMsg?.();
+    // refreshConv?.();
+    // refreshMsg?.();
+
+    updateCversion();
+    updateMVersion();
   };
 
   return (

--- a/src/features/chat/components/MessageList.tsx
+++ b/src/features/chat/components/MessageList.tsx
@@ -137,7 +137,6 @@ export default function MessageList({ userId }: { userId: string }) {
           value={chatInput}
           onChange={(e) => setChatInput(e.target.value)}
           onClear={() => setChatInput("")}
-          className=""
           userId={userId}
         />
       </div>

--- a/src/features/chat/components/Messages.tsx
+++ b/src/features/chat/components/Messages.tsx
@@ -2,14 +2,20 @@
 import { useParams } from "react-router";
 import MessageList from "./MessageList";
 import NoMessages from "./NoMessages";
+import { useMsgVersionStore } from "../stores/msgVersionStore";
 
 export default function Messages() {
   const { userId } = useParams();
+  const version = useMsgVersionStore((state) => state.m_version);
 
   return (
     <>
       <div className="md:w-[55%] h-[93%] md:p-8 rounded-4xl md:border border-[var(--primary-300)] flex justify-center items-center">
-        {userId ? <MessageList userId={userId} /> : <NoMessages />}
+        {userId ? (
+          <MessageList key={`${userId}-${version}`} userId={userId} />
+        ) : (
+          <NoMessages />
+        )}
       </div>
     </>
   );

--- a/src/features/chat/components/TextBox.tsx
+++ b/src/features/chat/components/TextBox.tsx
@@ -1,6 +1,7 @@
 import { Send } from "lucide-react";
 import useSendMessage from "../hooks/useSendMessage";
-import { useRefreshStore } from "../stores/refreshStore";
+// import { useRefreshStore } from "../stores/refreshStore";
+import { useMsgVersionStore } from "../stores/msgVersionStore";
 
 interface SearchBarProps {
   value: string;
@@ -20,7 +21,9 @@ export default function TextBox({
   userId,
 }: SearchBarProps) {
   const sendMessage = useSendMessage();
-  const refreshMessages = useRefreshStore((state) => state.refreshMessages);
+  // const refreshMessages = useRefreshStore((state) => state.refreshMessages);
+  const updateCVersion = useMsgVersionStore((state) => state.c_increment);
+  const updateMVersion = useMsgVersionStore((state) => state.m_increment);
 
   const sendMsgHandler = async (e: React.FormEvent | React.MouseEvent) => {
     e.preventDefault();
@@ -29,7 +32,10 @@ export default function TextBox({
 
     await sendMessage({ message: value, userId });
 
-    refreshMessages?.();
+    // refreshMessages?.();
+    updateCVersion();
+    updateMVersion();
+
     onClear();
   };
 

--- a/src/features/chat/hooks/useGetMessages.ts
+++ b/src/features/chat/hooks/useGetMessages.ts
@@ -51,7 +51,7 @@ export default function useGetMessages(userId: string) {
         createdAt: formatTime(new Date(msg.createdAt)),
       }));
 
-      setMessages(msgData);
+      setMessages([...msgData]);
 
       console.log("fetch messages");
     } catch (error) {

--- a/src/features/chat/stores/msgVersionStore.ts
+++ b/src/features/chat/stores/msgVersionStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+type MsgVersionStore = {
+  c_version: number;
+  m_version: number;
+  c_increment: () => void;
+  m_increment: () => void;
+  reset: () => void;
+};
+
+export const useMsgVersionStore = create<MsgVersionStore>((set) => ({
+  c_version: 0,
+  m_version: 0,
+  c_increment: () => set((state) => ({ c_version: state.c_version + 1 })),
+  m_increment: () => set((state) => ({ m_version: state.m_version + 1 })),
+  reset: () => set({ c_version: 0, m_version: 0 }),
+}));

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -2,10 +2,12 @@ import { useParams } from "react-router";
 import BackButton from "../components/common/BackButton";
 import Conversations from "../features/chat/components/Conversations";
 import Messages from "../features/chat/components/Messages";
+import { useMsgVersionStore } from "../features/chat/stores/msgVersionStore";
 // import { UserInfo } from "../features/chat/types/UserInfo";
 
 export default function Chat() {
   const { userId } = useParams();
+  const version = useMsgVersionStore((state) => state.c_version);
 
   return (
     <>
@@ -24,7 +26,7 @@ export default function Chat() {
             <BackButton />
           </div>
           <div className="h-[93%] w-full">
-            <Conversations />
+            <Conversations key={`${userId}-${version}`} />
           </div>
         </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
채팅 url에 userId 넣는 방식으로 변경하면서 기존 방식으로는 컴포넌트 렌더링이 안되어 업데이트 안되는 이슈 발생

> 새로고침 버튼 기능 수정
> 메세지 전송 시 자동 업데이트 기능 수정

### 스크린샷

## 💬리뷰 요구사항
> 메세지 전송 시, 새로고침 버튼 클릭 시 -> 왼쪽 대화 목록, 오른쪽 상세 대화 목록 업데이트
