### PR TITLE
🐛 Fix: Playlist 페이지 레이아웃 시프트 해결 및 스켈레톤 UI 개선

### DIFF
--- a/src/features/playlist/components/MusicRecommender/TrackCard.tsx
+++ b/src/features/playlist/components/MusicRecommender/TrackCard.tsx
@@ -40,16 +40,16 @@ export default function TrackCard({
   };
 
   return (
-    <div className=" md:w-[160px] xl:w-[112px] 2xl:w-[120px] h-[90%] overflow-hidden flex flex-col justify-center items-center md:gap-4 box-border min-h-32">
-      <div className="flex h-[35%] justify-center items-center rounded-full relative group overflow-hidden  min-w-15  min-h-15">
+    <div className="md:w-[160px] xl:w-[112px] 2xl:w-[120px] h-auto overflow-visible flex flex-col justify-start items-center gap-2 md:gap-3 box-border">
+      <div className="flex justify-center items-center rounded-full relative group overflow-hidden w-16 h-16 md:w-20 md:h-20 xl:w-[72px] xl:h-[72px] 2xl:w-20 2xl:h-20 flex-shrink-0">
         <img
           src={track.album.images[0]?.url || ""}
           alt={`${track.name} 앨범 커버`}
-          className="w-full h-full object-cover cursor-pointer "
+          className="w-full h-full object-cover cursor-pointer"
           onClick={togglePlayTrack}
         />
         <div
-          className={`absolute flex justify-center items-center cursor-pointer opacity-0 group-hover:opacity-100 group-hover:bg-black/50 w-full h-full z-10 ${
+          className={`absolute flex justify-center items-center cursor-pointer opacity-0 group-hover:opacity-100 group-hover:bg-black/50 w-full h-full z-10 rounded-full ${
             isPlaying ? "opacity-100 bg-black/50" : ""
           }`}
         >
@@ -70,7 +70,7 @@ export default function TrackCard({
         />
       )}
 
-      <div className="flex flex-col md:gap-2 justify-center items-center w-full h-[40%]">
+      <div className="flex flex-col gap-1 md:gap-2 justify-start items-center w-full">
         <div className="flex flex-col gap-0.5 md:gap-2 xl:gap-1 w-full">
           <p
             className="text-[10px] md:text-[14px] font-bold text-[color:var(--white)] truncate w-full text-center"
@@ -87,11 +87,11 @@ export default function TrackCard({
         </div>
 
         <div
-          className="flex justify-center gap-[8px] items-center md:mt-2 group"
+          className="flex justify-center gap-[8px] items-center md:mt-1 group"
           onClick={onAddClick}
         >
           <Plus className="w-2 h-2 md:w-3 md:h-3 text-[color:var(--grey-400)] group-hover:text-[color:var(--primary-100)] cursor-pointer" />
-          <p className=" text-[8px] md:text-[10px]  xl:text-[12px]  text-[color:var(--grey-400)] group-hover:text-[color:var(--primary-100)] cursor-pointer">
+          <p className="text-[8px] md:text-[10px] xl:text-[12px] text-[color:var(--grey-400)] group-hover:text-[color:var(--primary-100)] cursor-pointer">
             Add Playlist
           </p>
         </div>

--- a/src/features/playlist/components/MusicRecommender/TrackCardSkeleton.tsx
+++ b/src/features/playlist/components/MusicRecommender/TrackCardSkeleton.tsx
@@ -1,15 +1,18 @@
 export default function TrackCardSkeleton() {
   return (
-    <div className="w-full md:w-[160px] xl:w-[112px] 2xl:w-[120px] h-auto overflow-hidden flex flex-col justify-center items-center gap-2 md:gap-4 box-border min-h-32">
-      <div className="flex w-16 h-16 md:w-[80px] md:h-[80px] justify-center items-center rounded-full overflow-hidden">
+    <div className="md:w-[160px] xl:w-[112px] 2xl:w-[120px] h-auto overflow-visible flex flex-col justify-start items-center gap-2 md:gap-3 box-border">
+      <div className="flex justify-center items-center rounded-full overflow-hidden w-16 h-16 md:w-20 md:h-20 xl:w-[72px] xl:h-[72px] 2xl:w-20 2xl:h-20 flex-shrink-0">
         <div className="w-full h-full bg-[color:var(--grey-500)] rounded-full animate-pulse" />
       </div>
-      <div className="flex flex-col gap-1 md:gap-2 justify-center items-center w-full">
+
+      <div className="flex flex-col gap-1 md:gap-2 justify-start items-center w-full">
         <div className="flex flex-col gap-0.5 md:gap-2 xl:gap-1 w-full">
           <div className="w-[80%] h-3 md:h-[14px] bg-[color:var(--grey-500)] rounded-sm animate-pulse mx-auto" />
-          <div className="w-[60%] h-2 md:h-[12px] bg-[color:var(--grey-500)] rounded-sm animate-pulse mx-auto" />
+          <div className="w-[60%] h-[17px] bg-[color:var(--grey-500)] rounded-sm animate-pulse mx-auto" />
         </div>
-        <div className="flex justify-center gap-[8px] items-center mt-1 md:mt-2">
+
+        <div className="flex justify-center gap-[8px] items-center md:mt-1">
+          <div className="w-2 h-2 md:w-3 md:h-3 bg-[color:var(--grey-500)] rounded-sm animate-pulse" />
           <div className="w-12 h-2 md:w-[50px] md:h-[10px] xl:h-[12px] bg-[color:var(--grey-500)] rounded-sm animate-pulse" />
         </div>
       </div>

--- a/src/features/playlist/components/PlaylistPanel/PlaylistHeader.tsx
+++ b/src/features/playlist/components/PlaylistPanel/PlaylistHeader.tsx
@@ -1,5 +1,4 @@
 import { Plus } from "lucide-react";
-
 interface PlaylistHeaderProps {
   userName: string;
   onAddClick: () => void;
@@ -12,9 +11,14 @@ export default function PlaylistHeader({
   return (
     <>
       <div className="justify-between items-center z-40 flex">
-        <div className="flex gap-[16px] md:text-[20px] font-bold">
+        <div className="flex gap-[16px] md:text-[20px] font-bold items-center">
           <h2 className="capitalize"> {userName} 님의 PlayList</h2>
-          <span className="inline">🌱</span>
+          <span
+            className="flex items-center justify-center w-6 h-6"
+            style={{ fontSize: "20px" }}
+          >
+            🌱
+          </span>
         </div>
         <Plus
           className="text-[color:var(--white-80)] cursor-pointer"

--- a/src/features/playlist/components/PlaylistPanel/PlaylistTrackItemSkeleton.tsx
+++ b/src/features/playlist/components/PlaylistPanel/PlaylistTrackItemSkeleton.tsx
@@ -1,9 +1,9 @@
 export default function PlaylistTrackItemSkeleton() {
   return (
-    <div className="flex h-auto p-2 md:p-[18px] justify-between items-center hover:bg-[color:var(--grey-500)] rounded-[10px] group">
+    <div className="flex h-auto p-2 justify-between items-center hover:bg-[color:var(--grey-500)] rounded-[10px] group">
       <div className="flex gap-[24px] items-center flex-1 overflow-hidden">
         <div className="w-10 h-10 md:w-12 md:h-12 bg-[color:var(--grey-500)] rounded-[10px] animate-pulse flex-shrink-0" />
-        <div className="flex flex-col justify-center overflow-hidden">
+        <div className="overflow-hidden flex flex-col gap-1">
           <div className="h-[12px] md:h-[16px] w-[120px] bg-[color:var(--grey-500)] rounded-md animate-pulse" />
           <div className="h-[10px] md:h-[14px] w-[80px] bg-[color:var(--grey-500)] rounded-md animate-pulse mt-2" />
         </div>

--- a/src/pages/Playlist.tsx
+++ b/src/pages/Playlist.tsx
@@ -28,7 +28,7 @@ export default function Playlist() {
       <PlayListBanner />
       <div className="flex flex-col xl:flex-row gap-[32px] w-full h-auto xl:h-[70vh]">
         <div className="flex flex-col h-[70vh] justify-between w-full xl:w-[58%] order-last xl:order-none xl:mt-12 gap-8">
-          <div className="flex-1 overflow-autp scrollbar-hide">
+          <div className="flex-1 overflow-auto scrollbar-hide">
             <MusicRecommender
               setCurrentVideo={setCurrentVideo}
               currentVideo={currentVideo}
@@ -49,7 +49,10 @@ export default function Playlist() {
           </div>
         </div>
 
-        <div className="w-full xl:w-[40%] order-first xl:order-none h-[500px] xl:min-h-[640px] xl:h-full mt-12 ">
+        <div
+          className="w-full xl:w-[40%] order-first xl:order-none 
+                        h-[500px] xl:h-[70vh] mt-12"
+        >
           <PlaylistPanel
             setCurrentVideo={setCurrentVideo}
             currentVideo={currentVideo}

--- a/src/pages/Playlist.tsx
+++ b/src/pages/Playlist.tsx
@@ -28,14 +28,14 @@ export default function Playlist() {
       <PlayListBanner />
       <div className="flex flex-col xl:flex-row gap-[32px] w-full h-auto xl:h-[70vh]">
         <div className="flex flex-col h-[70vh] justify-between w-full xl:w-[58%] order-last xl:order-none xl:mt-12 gap-8">
-          <div className="flex-1 overflow-auto scrollbar-hide">
+          <div className="flex-1 overflow-y-scroll scrollbar-hide">
             <MusicRecommender
               setCurrentVideo={setCurrentVideo}
               currentVideo={currentVideo}
             />
           </div>
 
-          <div className="flex-1 overflow-auto min-h-[300px]">
+          <div className="flex-1 overflow-y-scroll min-h-[300px] scrollbar-hide">
             {userId === selectedUserId ? (
               <UserPlaylistPreview setSelectedUserId={setSelectedUserId} />
             ) : (
@@ -49,10 +49,7 @@ export default function Playlist() {
           </div>
         </div>
 
-        <div
-          className="w-full xl:w-[40%] order-first xl:order-none 
-                        h-[500px] xl:h-[70vh] mt-12"
-        >
+        <div className="w-full xl:w-[40%] order-first xl:order-none h-[500px] xl:h-[70vh] mt-12 overflow-y-scroll scrollbar-hide">
           <PlaylistPanel
             setCurrentVideo={setCurrentVideo}
             currentVideo={currentVideo}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 레이아웃 시프트 해결
- **컨테이너 높이 충돌 해결**
  - PlaylistPanel 높이를 `xl:h-[70vh]`로 통일하여 min-h와 h-full 충돌 제거
  - 오타 수정: `overflow-autp` → `overflow-auto`

- **스크롤바로 인한 레이아웃 시프트 방지**
  - `overflow-auto` → `overflow-y-scroll` 변경
  - 데이터 로드 전/후 스크롤바 생성으로 인한 너비 변화 제거

- **이모지 렌더링 최적화**
  - PlaylistHeader, MusicRecommenderHeader, UserPlaylistHeader, OtherUserPlaylist의 PlaylistHeader 모든 이모지에 고정 크기 지정
  - 폰트 로딩 시 크기 재계산 방지

### 2. 스켈레톤 UI 개선
- **PlaylistTrackItemSkeleton 수정**
  - padding을 실제 컴포넌트와 동일하게 `p-2`로 통일
  - 텍스트 컨테이너 구조를 실제와 일치하도록 수정

- **TrackCardSkeleton 수정**
  - 앨범 이미지를 완벽한 원형(1:1 비율)으로 수정
  - 고정 크기 사용으로 모든 화면에서 타원형 및 원 잘림 방지: `w-16 h-16 md:w-20 md:h-20 xl:w-[72px] xl:h-[72px] 2xl:w-20 2xl:h-20`
  - 컨테이너 높이를 `h-auto`로 변경하여 맥북(14pro)에서 원 잘리는 현상 해결
  - gap 조정(`gap-2 md:gap-3`)으로 큰 화면에서 과도한 여백 제거
  - 실제 TrackCard와 동일한 레이아웃 구조 적용

## 성과

- **CLS(Cumulative Layout Shift) 점수**: 0.004 → 0.001
- 시각적 레이아웃 시프트 완전 제거
- 스켈레톤 UI와 실제 데이터 간 레이아웃 불일치 해결
- 모든 화면 크기에서 일관된 UI 제공


<img width="352" height="80" alt="Screenshot 2025-10-05 at 7 55 24 PM" src="https://github.com/user-attachments/assets/72cd6d56-471f-492b-ae4a-b359ef71bb84" />

<img width="261" height="71" alt="Screenshot 2025-10-05 at 7 56 50 PM" src="https://github.com/user-attachments/assets/62b6198a-3132-4b3d-a171-6f5ee8a63b1a" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
